### PR TITLE
feat: Executor Playwright MCP Tool Loader の実装 (#3)

### DIFF
--- a/src/plan_and_act/utils/mcp_tools.py
+++ b/src/plan_and_act/utils/mcp_tools.py
@@ -1,0 +1,44 @@
+from typing import List
+from langchain_core.tools import BaseTool
+from langchain_mcp_adapters.client import MultiServerMCPClient
+import logging
+
+logger = logging.getLogger(__name__)
+
+# TODO: 設定値は将来的にYAMLや環境変数から取得する
+PLAYWRIGHT_MCP_SSE_URL = "http://localhost:8931/sse"
+
+async def load_playwright_tools(transport: str = "sse") -> List[BaseTool]:
+    """
+    Playwright MCP Server から利用可能なツールをロードするユーティリティ関数。
+    transport: "sse" または "stdio" を指定可能（デフォルトはSSE）。
+    Returns:
+        List[BaseTool]: 利用可能なLangChainツールのリスト
+    """
+    if transport == "sse":
+        client_config = {
+            "playwright_sse": {
+                "url": PLAYWRIGHT_MCP_SSE_URL,
+                "transport": "sse"
+            }
+        }
+        server_name = "playwright_sse"
+    elif transport == "stdio":
+        client_config = {
+            "playwright_stdio": {
+                "command": "npx",
+                "args": ["@playwright/mcp@latest", "--headless"],
+                "transport": "stdio"
+            }
+        }
+        server_name = "playwright_stdio"
+    else:
+        raise ValueError(f"Unsupported transport: {transport}")
+
+    try:
+        async with MultiServerMCPClient(client_config) as mcp_client:
+            tools = await mcp_client.get_tools(server_name=server_name)
+        return tools
+    except Exception as e:
+        logger.error(f"MCPツールのロードに失敗しました: {e}")
+        return [] 


### PR DESCRIPTION
Closes #3

## 概要
- Playwright MCP Server から利用可能なツールをLangChain `Tool` オブジェクトとしてロードする非同期関数 `load_playwright_tools` を `src/plan_and_act/utils/mcp_tools.py` に実装しました。
- SSE・Stdio両対応の構造で、現状はSSEをデフォルトとしています。
- 設定値の外部化や高度なエラーハンドリングは今後のIssueで対応予定です。

## 変更内容
- `src/plan_and_act/utils/mcp_tools.py` 新規作成
- `load_playwright_tools` 非同期関数の実装（SSE・Stdio両対応）

詳細は Issue #3 および `docs/04_tool_integration_mcp.md` を参照してください。