### PR TITLE
feat: Implement Initial Planner Node (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ plan-and-act-infer/
 │       ├── core/                # Planner / Executor / Memory / Tools (雛形)
 │       │   ├── agent_base.py
 │       │   ├── memory.py
+│       │   ├── planner.py       # ✅ Planner実装
 │       │   └── tools.py
 │       ├── graphs/              # LangGraph 推論フロー（雛形）
 │       │   └── inference_graph.py
@@ -55,10 +56,55 @@ plan-and-act-infer/
 │   └── settings.yaml            # アプリケーション設定
 ├── tests/                       # pytest テスト
 │   ├── conftest.py
-│   └── test_dummy.py
+│   ├── test_dummy.py
+│   ├── test_memory.py
+│   ├── test_tools.py
+│   └── test_planner.py          # ✅ Plannerテスト
 ├── .env.example                 # 環境変数のサンプル
 └── ...
 ```
+
+---
+
+## 🏗️ Plan-and-Act アーキテクチャ
+
+### Planner コンポーネント
+
+Planner は、高レベルのタスクを実行可能なステップに分解し、実行結果に基づいて動的に計画を調整する責務を持ちます。
+
+#### 主要機能
+
+1. **初期計画生成**
+   - ユーザーの目標を理解し、実行可能なステップのリストを生成
+   - 各ステップには、番号、理由付け（reasoning）、具体的なアクションを含む
+
+2. **動的再計画**
+   - エグゼキューターからのフィードバックに基づいて計画を評価
+   - エラーや予期しない結果に対して代替案を生成
+   - 既に成功したステップは保持しつつ、失敗したステップを修正
+
+3. **再計画判定**
+   - 観測結果からエラーキーワードを検出し、再計画の必要性を判断
+   - エラー、失敗、タイムアウトなどの問題を自動検出
+
+#### データモデル
+
+```python
+class PlanStep:
+    step_number: int      # ステップ番号
+    reasoning: str        # そのステップが必要な理由
+    step: str            # 実行すべき高レベルタスク
+
+class Plan:
+    steps: List[PlanStep]  # 計画ステップのリスト
+```
+
+#### LangGraph統合
+
+Planner は LangGraph のノードとして動作し、以下の状態を管理します：
+
+- **入力**: `goal`（目標）、`history`（実行履歴）、`observation`（最新の観測）
+- **出力**: `plan`（計画ステップのリスト）、`needs_replan`（再計画フラグ）
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,3 +33,8 @@ line-length = 120
 select = ["E", "F", "W", "I", "N", "UP", "B", "A", "C4", "T20", "SIM", "Q", "RUF"]
 ignore = []
 fix = true 
+
+[dependency-groups]
+dev = [
+    "pytest-asyncio>=0.26.0",
+]

--- a/src/plan_and_act/core/__init__.py
+++ b/src/plan_and_act/core/__init__.py
@@ -6,8 +6,20 @@ __all__ = [
     "AgentBase",
     "Memory",
     "ToolRegistry",
+    "Plan",
+    "PlanStep",
+    "Planner",
+    "create_planner",
+    "planner_node",
 ]
 
 from .agent_base import AgentBase  # pragma: no cover
 from .memory import Memory  # pragma: no cover
 from .tools import ToolRegistry  # pragma: no cover
+from .planner import (  # pragma: no cover
+    Plan,
+    PlanStep,
+    Planner,
+    create_planner,
+    planner_node,
+)

--- a/src/plan_and_act/core/planner.py
+++ b/src/plan_and_act/core/planner.py
@@ -1,0 +1,297 @@
+"""
+Plan-and-Act フレームワークの Planner コンポーネント
+
+このモジュールは、タスクの計画生成と動的再計画を担当する Planner を実装します。
+Planner は、高レベルのタスク目標を実行可能なステップに分解し、
+実行結果に基づいて計画を調整します。
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from langchain_core.messages import BaseMessage, HumanMessage, SystemMessage
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from langchain_core.language_models import BaseChatModel
+
+
+class PlanStep(BaseModel):
+    """単一の計画ステップを表すモデル"""
+    
+    step_number: int = Field(description="ステップ番号（1から始まる連番）")
+    reasoning: str = Field(description="このステップが必要な理由・論理的根拠")
+    step: str = Field(description="実行すべき高レベルタスクの説明")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """辞書形式に変換"""
+        return {
+            "step_number": self.step_number,
+            "reasoning": self.reasoning,
+            "step": self.step,
+        }
+
+
+class Plan(BaseModel):
+    """計画全体を表すモデル"""
+    
+    steps: List[PlanStep] = Field(description="計画ステップのリスト")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """辞書形式に変換"""
+        return {
+            "steps": [step.to_dict() for step in self.steps]
+        }
+
+
+# プランナー用のシステムプロンプトテンプレート
+PLANNER_SYSTEM_PROMPT = """あなたはタスク計画を専門とするAIアシスタントです。
+ユーザーの目標に基づいて、実行可能なステップからなる詳細な計画を作成してください。
+
+重要な原則:
+1. 各ステップは独立して実行可能で、明確な成果を持つこと
+2. ステップ間の依存関係を考慮し、論理的な順序で配置すること
+3. 各ステップは具体的で、実行者が迷わないよう明確に記述すること
+4. 必要に応じて、エラーハンドリングや代替案を考慮すること
+
+出力形式:
+必ず以下のJSON形式で出力してください。他の形式や説明文は含めないでください。
+
+```json
+{
+  "steps": [
+    {
+      "step_number": 1,
+      "reasoning": "このステップが必要な理由や戦略的根拠",
+      "step": "実行すべき高レベルタスクの明確な説明"
+    },
+    {
+      "step_number": 2,
+      "reasoning": "...",
+      "step": "..."
+    }
+  ]
+}
+```"""
+
+# 再計画用のシステムプロンプトテンプレート
+REPLANNING_SYSTEM_PROMPT = """あなたはタスク計画を専門とするAIアシスタントです。
+現在の計画の実行状況と観測結果に基づいて、計画を見直し、必要に応じて修正・更新してください。
+
+重要な原則:
+1. 既に成功したステップは変更しない
+2. 失敗や予期しない結果に対して、適切な代替案を提供する
+3. 新しい情報を活用して、より効果的な計画に更新する
+4. 目標達成の可能性を最大化する
+
+現在の状況:
+- 元の目標: {goal}
+- 現在の計画: {current_plan}
+- 実行履歴: {history}
+- 最新の観測: {observation}
+
+出力形式:
+必ず以下のJSON形式で出力してください。他の形式や説明文は含めないでください。
+
+```json
+{{
+  "steps": [
+    {{
+      "step_number": 1,
+      "reasoning": "このステップが必要な理由（既存ステップの場合は変更理由）",
+      "step": "実行すべき高レベルタスクの明確な説明"
+    }}
+  ]
+}}
+```"""
+
+
+class Planner:
+    """タスクの計画生成と動的再計画を行うクラス"""
+    
+    def __init__(self, llm: BaseChatModel):
+        """
+        Args:
+            llm: 使用する言語モデル
+        """
+        self.llm = llm
+        
+    def _parse_plan_response(self, response: str) -> Plan:
+        """LLMの応答から計画を抽出してPlanオブジェクトに変換"""
+        try:
+            # JSON部分を抽出（```json ... ```の形式に対応）
+            if "```json" in response:
+                start = response.find("```json") + 7
+                end = response.find("```", start)
+                json_str = response[start:end].strip()
+            else:
+                # 全体をJSONとして扱う
+                json_str = response.strip()
+            
+            # JSONをパース
+            data = json.loads(json_str)
+            
+            # Planオブジェクトに変換
+            steps = []
+            for step_data in data.get("steps", []):
+                step = PlanStep(
+                    step_number=step_data["step_number"],
+                    reasoning=step_data["reasoning"],
+                    step=step_data["step"]
+                )
+                steps.append(step)
+            
+            return Plan(steps=steps)
+            
+        except (json.JSONDecodeError, KeyError, ValueError) as e:
+            # パースエラーの場合は空の計画を返す
+            # 実際の運用では適切なエラーハンドリングが必要
+            return Plan(steps=[])
+    
+    async def generate_initial_plan(self, goal: str) -> Plan:
+        """
+        初期計画を生成する
+        
+        Args:
+            goal: ユーザーの目標・タスク
+            
+        Returns:
+            生成された計画
+        """
+        messages = [
+            SystemMessage(content=PLANNER_SYSTEM_PROMPT),
+            HumanMessage(content=f"目標: {goal}")
+        ]
+        
+        response = await self.llm.ainvoke(messages)
+        return self._parse_plan_response(response.content)
+    
+    async def replan(
+        self,
+        goal: str,
+        current_plan: Plan,
+        history: List[Dict[str, Any]],
+        observation: str
+    ) -> Plan:
+        """
+        現在の状況に基づいて計画を再生成する
+        
+        Args:
+            goal: 元の目標
+            current_plan: 現在の計画
+            history: 実行履歴
+            observation: 最新の観測結果
+            
+        Returns:
+            更新された計画
+        """
+        # 現在の計画を文字列化
+        current_plan_str = json.dumps(current_plan.to_dict(), ensure_ascii=False, indent=2)
+        
+        # 履歴を文字列化
+        history_str = json.dumps(history, ensure_ascii=False, indent=2)
+        
+        prompt = REPLANNING_SYSTEM_PROMPT.format(
+            goal=goal,
+            current_plan=current_plan_str,
+            history=history_str,
+            observation=observation
+        )
+        
+        messages = [
+            SystemMessage(content=prompt)
+        ]
+        
+        response = await self.llm.ainvoke(messages)
+        return self._parse_plan_response(response.content)
+    
+    def needs_replan(self, observation: str) -> bool:
+        """
+        観測結果から再計画が必要かどうかを判定する
+        
+        Args:
+            observation: エグゼキューターからの観測結果
+            
+        Returns:
+            再計画が必要な場合True
+        """
+        # エラーや失敗を示すキーワードをチェック
+        error_indicators = [
+            "エラー", "失敗", "見つかりません", "アクセスできません",
+            "error", "failed", "not found", "cannot access",
+            "exception", "timeout", "unable to", "denied"
+        ]
+        
+        observation_lower = observation.lower()
+        return any(indicator in observation_lower for indicator in error_indicators)
+
+
+def create_planner(llm: BaseChatModel) -> Planner:
+    """
+    Plannerインスタンスを作成するファクトリメソッド
+    
+    Args:
+        llm: 使用する言語モデル
+        
+    Returns:
+        Plannerインスタンス
+    """
+    return Planner(llm=llm)
+
+
+# LangGraphノードとして動作する関数
+async def planner_node(state: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    LangGraphのノードとして動作するプランナー関数
+    
+    Args:
+        state: グラフの状態
+        
+    Returns:
+        更新された状態
+    """
+    # LLMインスタンスを取得（実際の実装では設定から取得）
+    # stateまたは環境からLLMを取得する
+    llm = state.get("llm")
+    if not llm:
+        # デフォルトのLLMを作成（実際の実装では設定ファイルから読み込む）
+        try:
+            from langchain_anthropic import ChatAnthropic
+            llm = ChatAnthropic(model="claude-3-sonnet-20241022")
+        except ImportError:
+            # テスト環境などでAnthropicが利用できない場合のフォールバック
+            raise ValueError("LLM instance not found in state and ChatAnthropic not available")
+    
+    planner = create_planner(llm)
+    
+    # 初期計画生成か再計画かを判定
+    if not state.get("plan") or state.get("needs_replan", False):
+        if not state.get("plan"):
+            # 初期計画生成
+            plan = await planner.generate_initial_plan(state["goal"])
+        else:
+            # 再計画
+            current_plan = Plan(steps=[
+                PlanStep(**step) for step in state["plan"]
+            ])
+            plan = await planner.replan(
+                goal=state["goal"],
+                current_plan=current_plan,
+                history=state.get("history", []),
+                observation=state.get("observation", "")
+            )
+        
+        return {
+            "plan": [step.to_dict() for step in plan.steps],
+            "current_step_idx": state.get("current_step_idx", 0),
+            "needs_replan": False
+        }
+    
+    # 計画の変更が不要な場合
+    return {
+        "plan": state["plan"],
+        "needs_replan": False
+    } 

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,355 @@
+"""
+Planner コンポーネントのユニットテスト
+"""
+
+import json
+from typing import Any, Dict, List
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, BaseMessage
+
+from plan_and_act.core.planner import (
+    Plan,
+    PlanStep,
+    Planner,
+    create_planner,
+    planner_node,
+)
+
+
+class TestPlanStep:
+    """PlanStepクラスのテスト"""
+    
+    def test_plan_step_creation(self):
+        """PlanStepが正しく作成できることを確認"""
+        step = PlanStep(
+            step_number=1,
+            reasoning="最初にウェブサイトにアクセスする必要がある",
+            step="指定されたURLにナビゲートする"
+        )
+        
+        assert step.step_number == 1
+        assert step.reasoning == "最初にウェブサイトにアクセスする必要がある"
+        assert step.step == "指定されたURLにナビゲートする"
+    
+    def test_plan_step_to_dict(self):
+        """PlanStepが正しく辞書に変換できることを確認"""
+        step = PlanStep(
+            step_number=2,
+            reasoning="検索を実行するため",
+            step="検索ボックスにキーワードを入力"
+        )
+        
+        expected = {
+            "step_number": 2,
+            "reasoning": "検索を実行するため",
+            "step": "検索ボックスにキーワードを入力"
+        }
+        
+        assert step.to_dict() == expected
+
+
+class TestPlan:
+    """Planクラスのテスト"""
+    
+    def test_plan_creation(self):
+        """Planが正しく作成できることを確認"""
+        steps = [
+            PlanStep(step_number=1, reasoning="理由1", step="ステップ1"),
+            PlanStep(step_number=2, reasoning="理由2", step="ステップ2"),
+        ]
+        
+        plan = Plan(steps=steps)
+        assert len(plan.steps) == 2
+        assert plan.steps[0].step_number == 1
+        assert plan.steps[1].step_number == 2
+    
+    def test_plan_to_dict(self):
+        """Planが正しく辞書に変換できることを確認"""
+        steps = [
+            PlanStep(step_number=1, reasoning="理由1", step="ステップ1"),
+        ]
+        
+        plan = Plan(steps=steps)
+        expected = {
+            "steps": [
+                {
+                    "step_number": 1,
+                    "reasoning": "理由1",
+                    "step": "ステップ1"
+                }
+            ]
+        }
+        
+        assert plan.to_dict() == expected
+
+
+class TestPlanner:
+    """Plannerクラスのテスト"""
+    
+    @pytest.fixture
+    def mock_llm(self):
+        """モックのLLMを作成"""
+        return AsyncMock()
+    
+    @pytest.fixture
+    def planner(self, mock_llm):
+        """テスト用のPlannerインスタンスを作成"""
+        return Planner(llm=mock_llm)
+    
+    def test_parse_plan_response_with_json_block(self, planner):
+        """JSONブロック形式のレスポンスを正しくパースできることを確認"""
+        response = """以下が計画です:
+        
+```json
+{
+  "steps": [
+    {
+      "step_number": 1,
+      "reasoning": "最初にページにアクセスする必要がある",
+      "step": "https://example.comにナビゲート"
+    },
+    {
+      "step_number": 2,
+      "reasoning": "検索を実行するため",
+      "step": "検索ボックスにキーワードを入力"
+    }
+  ]
+}
+```"""
+        
+        plan = planner._parse_plan_response(response)
+        
+        assert len(plan.steps) == 2
+        assert plan.steps[0].step_number == 1
+        assert plan.steps[0].reasoning == "最初にページにアクセスする必要がある"
+        assert plan.steps[1].step_number == 2
+    
+    def test_parse_plan_response_without_json_block(self, planner):
+        """JSONブロックなしのレスポンスを正しくパースできることを確認"""
+        response = """{
+  "steps": [
+    {
+      "step_number": 1,
+      "reasoning": "理由",
+      "step": "アクション"
+    }
+  ]
+}"""
+        
+        plan = planner._parse_plan_response(response)
+        
+        assert len(plan.steps) == 1
+        assert plan.steps[0].step_number == 1
+        assert plan.steps[0].step == "アクション"
+    
+    def test_parse_plan_response_with_invalid_json(self, planner):
+        """無効なJSONの場合、空の計画を返すことを確認"""
+        response = "これは無効なJSON"
+        
+        plan = planner._parse_plan_response(response)
+        
+        assert len(plan.steps) == 0
+    
+    @pytest.mark.asyncio
+    async def test_generate_initial_plan(self, planner, mock_llm):
+        """初期計画生成が正しく動作することを確認"""
+        # モックの設定
+        mock_response = AIMessage(content="""{
+  "steps": [
+    {
+      "step_number": 1,
+      "reasoning": "タスクを開始するため",
+      "step": "初期アクション"
+    }
+  ]
+}""")
+        mock_llm.ainvoke.return_value = mock_response
+        
+        # 実行
+        plan = await planner.generate_initial_plan("テストゴール")
+        
+        # 検証
+        assert len(plan.steps) == 1
+        assert plan.steps[0].step == "初期アクション"
+        mock_llm.ainvoke.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_replan(self, planner, mock_llm):
+        """再計画が正しく動作することを確認"""
+        # 現在の計画
+        current_plan = Plan(steps=[
+            PlanStep(step_number=1, reasoning="理由1", step="ステップ1")
+        ])
+        
+        # 履歴
+        history = [
+            {"step": "ステップ1", "observation": "エラーが発生しました"}
+        ]
+        
+        # モックの設定
+        mock_response = AIMessage(content="""{
+  "steps": [
+    {
+      "step_number": 1,
+      "reasoning": "エラーを回避するため代替案を実行",
+      "step": "代替ステップ1"
+    },
+    {
+      "step_number": 2,
+      "reasoning": "目標達成のため",
+      "step": "新しいステップ2"
+    }
+  ]
+}""")
+        mock_llm.ainvoke.return_value = mock_response
+        
+        # 実行
+        new_plan = await planner.replan(
+            goal="テストゴール",
+            current_plan=current_plan,
+            history=history,
+            observation="エラーが発生しました"
+        )
+        
+        # 検証
+        assert len(new_plan.steps) == 2
+        assert new_plan.steps[0].step == "代替ステップ1"
+        assert new_plan.steps[1].step == "新しいステップ2"
+        mock_llm.ainvoke.assert_called_once()
+    
+    def test_needs_replan_with_error_keywords(self, planner):
+        """エラーキーワードが含まれる場合、再計画が必要と判定されることを確認"""
+        error_observations = [
+            "エラーが発生しました",
+            "操作が失敗しました",
+            "ページが見つかりません",
+            "アクセスできません",
+            "An error occurred",
+            "Operation failed",
+            "Page not found",
+            "Cannot access the resource",
+            "Exception raised",
+            "Request timeout",
+            "Unable to complete",
+            "Permission denied",
+        ]
+        
+        for observation in error_observations:
+            assert planner.needs_replan(observation) is True
+    
+    def test_needs_replan_without_error_keywords(self, planner):
+        """エラーキーワードが含まれない場合、再計画不要と判定されることを確認"""
+        success_observations = [
+            "正常に完了しました",
+            "ページが表示されました",
+            "データを取得しました",
+            "Successfully completed",
+            "Page loaded",
+            "Data retrieved",
+        ]
+        
+        for observation in success_observations:
+            assert planner.needs_replan(observation) is False
+
+
+class TestFactoryAndNode:
+    """ファクトリ関数とノード関数のテスト"""
+    
+    def test_create_planner(self):
+        """create_planner関数が正しくインスタンスを作成することを確認"""
+        mock_llm = MagicMock()
+        planner = create_planner(mock_llm)
+        
+        assert isinstance(planner, Planner)
+        assert planner.llm == mock_llm
+    
+    @pytest.mark.asyncio
+    async def test_planner_node_initial_plan(self):
+        """planner_nodeが初期計画を生成することを確認"""
+        # モックLLMの設定
+        mock_llm = AsyncMock()
+        mock_response = AIMessage(content="""{
+  "steps": [
+    {
+      "step_number": 1,
+      "reasoning": "開始",
+      "step": "初期ステップ"
+    }
+  ]
+}""")
+        mock_llm.ainvoke.return_value = mock_response
+        
+        # 初期状態（計画なし）、LLMをstateに含める
+        state = {
+            "goal": "テストタスク",
+            "plan": None,
+            "needs_replan": False,
+            "llm": mock_llm  # LLMインスタンスを追加
+        }
+        
+        # 実行
+        result = await planner_node(state)
+        
+        # 検証
+        assert "plan" in result
+        assert len(result["plan"]) == 1
+        assert result["plan"][0]["step"] == "初期ステップ"
+        assert result["needs_replan"] is False
+    
+    @pytest.mark.asyncio
+    async def test_planner_node_replan(self):
+        """planner_nodeが再計画を実行することを確認"""
+        # モックLLMの設定
+        mock_llm = AsyncMock()
+        mock_response = AIMessage(content="""{
+  "steps": [
+    {
+      "step_number": 1,
+      "reasoning": "修正版",
+      "step": "修正されたステップ"
+    }
+  ]
+}""")
+        mock_llm.ainvoke.return_value = mock_response
+        
+        # 再計画が必要な状態
+        state = {
+            "goal": "テストタスク",
+            "plan": [{"step_number": 1, "reasoning": "元", "step": "元のステップ"}],
+            "needs_replan": True,
+            "history": [{"step": "元のステップ", "observation": "エラー"}],
+            "observation": "エラーが発生",
+            "llm": mock_llm  # LLMインスタンスを追加
+        }
+        
+        # 実行
+        result = await planner_node(state)
+        
+        # 検証
+        assert "plan" in result
+        assert len(result["plan"]) == 1
+        assert result["plan"][0]["step"] == "修正されたステップ"
+        assert result["needs_replan"] is False
+    
+    @pytest.mark.asyncio
+    async def test_planner_node_no_change_needed(self):
+        """planner_nodeが計画変更不要の場合、既存の計画を返すことを確認"""
+        # 計画変更不要な状態
+        existing_plan = [
+            {"step_number": 1, "reasoning": "既存", "step": "既存ステップ"}
+        ]
+        state = {
+            "goal": "テストタスク",
+            "plan": existing_plan,
+            "needs_replan": False,
+            "llm": AsyncMock()  # 使用されないがstateに含める
+        }
+        
+        # 実行
+        result = await planner_node(state)
+        
+        # 検証
+        assert result["plan"] == existing_plan
+        assert result["needs_replan"] is False 

--- a/uv.lock
+++ b/uv.lock
@@ -626,6 +626,11 @@ dev = [
     { name = "pytest-httpx" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "bump2version", marker = "extra == 'dev'" },
@@ -641,6 +646,9 @@ requires-dist = [
     { name = "ruff" },
     { name = "typer", specifier = ">=0.12" },
 ]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-asyncio", specifier = ">=0.26.0" }]
 
 [[package]]
 name = "platformdirs"
@@ -801,6 +809,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694 },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #21

## 概要
Plan-and-Act フレームワークの Planner コンポーネントを実装しました。

## 実装内容
- `core/planner.py` に Planner クラスを実装
  - `create_planner()` ファクトリメソッド
  - プロンプトテンプレートと構造化出力 (`PlanStep`, `Plan`)
  - 再計画ロジック (`needs_replan` 判定)
- LangGraph ノードとして動作する `planner_node` を実装
- 単体テストを作成（LLM 呼び出しはモック）
- ドキュメントに Planner のデザインを記載

## 主要機能
1. **初期計画生成**: ユーザーの目標を実行可能なステップに分解
2. **動的再計画**: エラーや予期しない結果に対して代替案を生成
3. **再計画判定**: 観測結果からエラーキーワードを検出し、再計画の必要性を判断

## テスト結果
- 全てのテストが成功（15個のテストケース）
- LLM呼び出しはモックで適切にテスト

## 今後の課題
- 設定ファイルからのLLMインスタンス取得機能の実装
- より高度な再計画判定ロジックの実装